### PR TITLE
Logged in users can edit and delete comment and posts.

### DIFF
--- a/delete_comment.php
+++ b/delete_comment.php
@@ -1,0 +1,24 @@
+<?php
+session_start();
+require 'config.php';
+
+// Check if the form was submitted
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // Get comment id and username
+    $commentID = $_POST['commentID'];
+    $username = $_SESSION['username'];
+
+    // Prepare prepared statement
+    $sql = "DELETE FROM Comments WHERE commentID = ? AND username = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("is", $commentID, $username);
+    
+    // Execute prepared statement
+    if($stmt->execute()) {
+        header("Location: index.php");
+        exit(); 
+    } else {
+        echo '<script>alert("Error '.$conn->error.'")</script>';
+    }
+}
+?>

--- a/delete_comment.php
+++ b/delete_comment.php
@@ -15,7 +15,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
     // Execute prepared statement
     if($stmt->execute()) {
-        header("Location: index.php");
+        header("Location: view_post.php?discussionID=".$_SESSION['discussionID']);
         exit(); 
     } else {
         echo '<script>alert("Error '.$conn->error.'")</script>';

--- a/delete_discussion.php
+++ b/delete_discussion.php
@@ -15,8 +15,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
     // Execute prepared statement
     if($stmt->execute()) {
-        echo '<script>alert("Discussion deleted successfully.")</script>';
         header("Location: index.php");
+        echo '<script>alert("Discussion deleted successfully.")</script>';
         exit(); 
     } else {
         echo '<script>alert("Error '.$conn->error.'")</script>';

--- a/delete_discussion.php
+++ b/delete_discussion.php
@@ -15,8 +15,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
     // Execute prepared statement
     if($stmt->execute()) {
-        header("Location: index.php");
-        echo '<script>alert("Discussion deleted successfully.")</script>';
+        echo '<script>
+                alert("Discussion deleted successfully.");
+                window.location.href = "index.php";
+              </script>';
         exit(); 
     } else {
         echo '<script>alert("Error '.$conn->error.'")</script>';

--- a/delete_discussion.php
+++ b/delete_discussion.php
@@ -9,8 +9,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $username = $_SESSION['username'];
 
     // Prepare prepared statement
-    $sql = "DELETE FROM Discussions WHERE discussionsID = ? AND username = ?";
-    $stmt = $conn->prepare($query);
+    $sql = "DELETE FROM Discussions WHERE discussionID = ? AND username = ?";
+    $stmt = $conn->prepare($sql);
     $stmt->bind_param("is", $discussionId, $username);
     
     // Execute prepared statement
@@ -18,7 +18,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         echo '<script>alert("Discussion deleted successfully.")</script>';
         header("Location: index.php");
         exit(); 
-    }; else {
+    } else {
         echo '<script>alert("Error '.$conn->error.'")</script>';
     }
 }

--- a/delete_discussion.php
+++ b/delete_discussion.php
@@ -15,10 +15,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
     // Execute prepared statement
     if($stmt->execute()) {
-        echo '<script>
-                alert("Discussion deleted successfully.");
-                window.location.href = "index.php";
-              </script>';
+        header("Location: index.php");
         exit(); 
     } else {
         echo '<script>alert("Error '.$conn->error.'")</script>';

--- a/delete_discussion.php
+++ b/delete_discussion.php
@@ -1,0 +1,25 @@
+<?php
+session_start();
+require 'config.php';
+
+// Check if the form was submitted
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // Get discussion id and username
+    $discussionId = $_POST['discussionID'];
+    $username = $_SESSION['username'];
+
+    // Prepare prepared statement
+    $sql = "DELETE FROM Discussions WHERE discussionsID = ? AND username = ?";
+    $stmt = $conn->prepare($query);
+    $stmt->bind_param("is", $discussionId, $username);
+    
+    // Execute prepared statement
+    if($stmt->execute()) {
+        echo '<script>alert("Discussion deleted successfully.")</script>';
+        header("Location: index.php");
+        exit(); 
+    }; else {
+        echo '<script>alert("Error '.$conn->error.'")</script>';
+    }
+}
+?>

--- a/edit_comment.php
+++ b/edit_comment.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+require 'config.php';
+
+// Check if the form was submitted
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // Get comment content, comment id and username
+    $updatedContent = $_POST['updatedContent'];
+    $commentID = $_POST['commentID'];
+    $username = $_SESSION['username'];
+
+    // Check if updated comment is empty
+    if (empty($updatedContent)) {
+        echo '<script>alert("Comment cannot be empty."); window.history.back();</script>';
+        exit();
+    }
+
+    // Prepare prepared statement
+    $sql = "UPDATE Comments SET content = ? WHERE commentID = ? AND username = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("sis", $updatedContent, $commentID, $username);
+    
+    // Execute prepared statement
+    if($stmt->execute()) {
+        header("Location: view_post.php?discussionID=".$_SESSION['discussionID']);
+        exit(); 
+    } else {
+        echo '<script>alert("Error '.$conn->error.'")</script>';
+    }
+}
+?>

--- a/edit_comment.php
+++ b/edit_comment.php
@@ -22,7 +22,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
     // Execute prepared statement
     if($stmt->execute()) {
-        header("Location: view_post.php?discussionID=".$_SESSION['discussionID']);
+        header("Location: index.php");
         exit(); 
     } else {
         echo '<script>alert("Error '.$conn->error.'")</script>';

--- a/edit_comment.php
+++ b/edit_comment.php
@@ -22,7 +22,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
     // Execute prepared statement
     if($stmt->execute()) {
-        header("Location: index.php");
+        header("Location: view_post.php?discussionID=".$_SESSION['discussionID']);
         exit(); 
     } else {
         echo '<script>alert("Error '.$conn->error.'")</script>';

--- a/edit_post.php
+++ b/edit_post.php
@@ -1,0 +1,48 @@
+<?php
+session_start();
+require 'config.php';
+
+// Check if the form was submitted
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    $title = $_POST['editPostTitle'];
+    $content = $_POST['editPostContent'];
+    $category = $_POST['editPostCategory'];
+
+
+    // Check if content is over limit
+    if (strlen($content) > 5000) {
+        $_SESSION['error_message'] = "Your post content exceeds the maximum allowed length of 5000 characters. Please shorten your post.";
+        header("Location: view_post.php?discussionID=".$_SESSION['discussionID']);
+        exit();
+    }
+
+    // Get image
+    $image = NULL;
+    // If image upload
+    if (isset($_FILES['editPostImage']) && $_FILES['editPostImage']['error'] == 0) {
+        // Check if file is over limit
+        if ($_FILES['editPostImage']['size'] > 2 * 1024 * 1024) {
+            $_SESSION['error_message'] = "The uploaded file exceeds the maximum allowed size of 2048 KiB. Please upload a smaller file.";
+            header("Location: view_post.php?discussionID=".$_SESSION['discussionID']);
+            exit();
+        }
+        $image = file_get_contents($_FILES['editPostImage']['tmp_name']);
+    }
+
+    // Create prepared statement and bind parameters
+    $sql = "UPDATE Discussions SET title = ?, content = ?, discussion_picture = ?, category = ? WHERE discussionID = ? AND username = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("ssssis", $title, $content, $image, $category, $_SESSION['discussionID'], $_SESSION['username']);
+
+    // Execute prepared statement
+    if ($stmt->execute()) {
+        header("Location: view_post.php?discussionID=".$_SESSION['discussionID']);
+    } else {
+        echo "Error: " . $stmt->error;
+    }
+    $stmt->close();
+    // $conn->close();
+} else {
+    echo "Invalid request.";
+}
+?>

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@
                         <div class="form-group row">
                             <label for="postCategory" class="col-sm-2 col-form-label">Category</label>
                             <div class="col-sm-10">
-                                <input type="text" class="form-control" id="postCategory" name="postCategory" placeholder="Enter post category">
+                                <input type="text" class="form-control" id="postCategory" name="postCategory" placeholder="Enter post category...">
                             </div>
                         </div>
                         <div class="form-group row">

--- a/index.php
+++ b/index.php
@@ -74,7 +74,6 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                            <!-- Submit button inside the form -->
                             <button type="submit" class="btn btn-primary">Post</button>
                         </div>
                     </form>

--- a/view_post.php
+++ b/view_post.php
@@ -169,14 +169,10 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
-            commentID = commentID.toString();
             document.getElementById('edit-form-' + commentID).style.display = "block";
-            // document.getElementById('comment-content-' + commentID).style.display = "none";
         }
         function cancelEdit(commentID) {
-            commentID = commentID.toString();
-            document.getElementById('comment-content-' + commentID).style.display = "none";
-            document.getElementById('edit-form-' + commentID).style = "block";
+            document.getElementById('edit-form-' + commentID).style = "none";
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -166,11 +166,11 @@
     <script>
         function editComment(commentID) {
             console.log('<?php echo $comment["content"]; ?>');
-            document.getElementById('comment-content-' + commentID).style.display = 'none';
+            document.getElementById('comment-' + commentID).style.display = 'none';
             document.getElementById('edit-form-' + commentID).style.display = 'block';
         }
         function cancelEdit(commentID) {
-            document.getElementById('comment-content-' + commentID).style.display = 'block';
+            document.getElementById('comment-' + commentID).style.display = 'block';
             document.getElementById('edit-form-' + commentID).style.display = 'none';
         }
     </script>

--- a/view_post.php
+++ b/view_post.php
@@ -169,7 +169,7 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
-            console.log(commentID);
+            commentID = commentID.toString();
             document.getElementById('comment-content-' + commentID).style.display = 'none';
             document.getElementById('edit-form-' + commentID).style.display = 'block';
         }

--- a/view_post.php
+++ b/view_post.php
@@ -88,7 +88,7 @@
                         echo '  <button onclick="editPost()" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
-                                    <button type="submit" class="btn btn-danger" style="text-align: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
+                                    <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
                                 </form>';
                     }
                 }

--- a/view_post.php
+++ b/view_post.php
@@ -169,7 +169,7 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
-            commentID = commentID.toString();
+            console.log(typeof commentID);
             document.getElementById('comment-content-' + commentID).style.display = 'none';
             document.getElementById('edit-form-' + commentID).style.display = 'block';
         }

--- a/view_post.php
+++ b/view_post.php
@@ -172,7 +172,7 @@
             document.getElementById('edit-form-' + commentID).style.display = "block";
         }
         function cancelEdit(commentID) {
-            document.getElementById('edit-form-' + commentID).style = "none";
+            document.getElementById('edit-form-' + commentID).style.display = "none";
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -119,8 +119,8 @@
                                                         <div id="comment-content-'.$comment['commentID'].'">
                                                             <p class="card-text">'.$comment['content'].'</p>
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:block;">
-                                                                <div class="card">
-                                                                    <div class="card-body" style="margin-bottom: 15px;">
+                                                                <div class="card" style="margin-bottom: 15px;">
+                                                                    <div class="card-body">
                                                                         <form method="post" action="edit_comment.php">
                                                                             <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
                                                                             <textarea class="form-control" name="updatedContent" rows="3" style="margin-bottom: 15px;">'.($comment['content']).'</textarea>

--- a/view_post.php
+++ b/view_post.php
@@ -52,7 +52,7 @@
                             <div class="col-12">
                                 <div class="card">
                                     <div class="card-body">
-                                        <p class="card-text"><strong>Posted by: ✏️ </strong>'.($row['username']).' | <strong>Published on:</strong> '.($row['time_posted']).' | <i><strong>'.($row['category']).'</strong></i></p>
+                                        <p class="card-text"><strong>✏️ Posted by: </strong>'.($row['username']).' | <strong>Published on:</strong> '.($row['time_posted']).' | <i><strong>'.($row['category']).'</strong></i></p>
                                         <h4 class="card-title">'.($row['title']).'</h4>
                                         <img src="data:image/jpeg;base64,'.$imageData.'" class="card-img-top img-fluid mx-auto d-block"
                                             style="max-width: 400px; margin-bottom: .25em;" alt="Discussion Image">
@@ -85,10 +85,11 @@
                     ';
                     // Display button to delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '<form method="post" action="delete_discussion.php">
-                                <input type="hidden" name="discussionID" value="'.$discussionId.'">
-                                <button type="submit" class="btn btn-danger" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
-                              </form>';
+                        echo '  <button onclick="editPost()" class="btn btn-outline-info">Edit Post</button>
+                                <form method="post" action="delete_discussion.php">
+                                    <input type="hidden" name="discussionID" value="'.$discussionId.'">
+                                    <button type="submit" class="btn btn-danger" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
+                                </form>';
                     }
                 }
                 echo '
@@ -117,7 +118,7 @@
                         echo '
                                                 <div class="card" id="comment-'.$comment['commentID'].'">
                                                     <div class="card-body">
-                                                        <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
+                                                        <p class="card-text"><strong>✏️ Written By: ' . $comment['username'] . ' | ' . $comment['timePosted'] . '</strong></p>
                                                         <div id="comment-content-'.$comment['commentID'].'" style="display:block;">
                                                             <p class="card-text">'.$comment['content'].'</p>
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
@@ -135,10 +136,10 @@
                         ';
                         if($_SESSION['username'] == $comment['username']) {
                             echo '
-                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: right;">Edit</button>
+                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: right; display: inline;" id="edit-comment-btn">Edit Comment</button>
                                                             <form method="post"  action="delete_comment.php" style="text-align: right;">
                                                                 <input type="hidden" name="commentID" value='.$comment['commentID'].'>
-                                                                <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete</button>
+                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: left; display: inline;" id="delete-comment-btn"onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
                                                             </form>
                             ';
                         }
@@ -172,9 +173,13 @@
     <script>
         function editComment(commentID) {
             document.getElementById('edit-form-' + commentID).style.display = "block";
+            document.getElementById('edit-comment-btn').style.display = "none";
+            document.getElementById('delete-comment-btn').style.display = "none";
         }
         function cancelEdit(commentID) {
             document.getElementById('edit-form-' + commentID).style.display = "none";
+            document.getElementById('edit-comment-btn').style.display = "block";
+            document.getElementById('delete-comment-btn').style.display = "none";
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -175,8 +175,8 @@
         }
         function cancelEdit(commentID) {
             commentID = commentID.toString();
-            // document.getElementById('comment-content-' + commentID).style.display = "block";
-            // document.getElementById('edit-form-' + commentID).style = "none";
+            document.getElementById('comment-content-' + commentID).style.display = "none";
+            document.getElementById('edit-form-' + commentID).style = "block";
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -61,7 +61,9 @@
                                         </div>
                                         <br>
                 ';
+                // If user is logged in
                 if (isset($_SESSION["logged_in"]) && $_SESSION["logged_in"] === true) {
+                    // Display create a comment form
                     echo '
                                                 <div class="card mb-3">
                                                     <div class="card-body">
@@ -78,6 +80,13 @@
                                                     </div>
                                                 </div>
                     ';
+                    // Display button to delete post if user is author of post
+                    if ($_SESSION['username'] == $row['username']) {
+                        echo '<form method="post" action="delete_discussion.php">
+                                <input type="hidden" name="discussionID" value="'.$discussionId.'">
+                                <button type="submit" class="btn btn-danger" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
+                              </form>';
+                    }
                 }
                 echo '
                                     </div>

--- a/view_post.php
+++ b/view_post.php
@@ -113,16 +113,21 @@
                                                 <div class="card" id="comment">
                                                     <div class="card-body">
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
-                            ';
-                                    
-                        // if ($comment['replyingTo'] != NULL) {
-                        //     echo '
-                        //                                 <p class="card-text">Responding To: ' . $comment['replyingTo'] . '</p>
-                        //     ';
-                        // }
-                        
-                        echo '
                                                         <p class="card-text">' . $comment['content'] . '</p>
+                        ';
+                        if($_SESSION['username'] == $comment['username']) {
+                            echo '
+                                                        <form method="post" action="edit_comment.php" style="text-align: right;">
+                                                            <input type="hidden" name="commentID" value='.$comment['commentID'].'>
+                                                            <button type="submit" class="btn btn-danger btn-sm";">Edit</button>
+                                                        </form>
+                                                        <form method="post"  action="delete_comment.php" style="text-align: right;">
+                                                            <input type="hidden" name="commentID" value='.$comment['commentID'].'>
+                                                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete</button>
+                                                        </form>
+                            ';
+                        }
+                        echo '
                                                     </div>
                                                 </div>
                             ';

--- a/view_post.php
+++ b/view_post.php
@@ -118,7 +118,7 @@
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
                                                         <div id="comment-content-'.$comment['commentID'].'" style="display:block;">
                                                             <p class="card-text">'.$comment['content'].'</p>
-                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:block;">
+                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
                                                                 <div class="card" style="margin-bottom: 15px;">
                                                                     <div class="card-body">
                                                                         <form method="post" action="edit_comment.php">
@@ -169,6 +169,7 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
+            console.log(commentID);
             document.getElementById('comment-content-' + commentID).style.display = 'none';
             document.getElementById('edit-form-' + commentID).style.display = 'block';
         }

--- a/view_post.php
+++ b/view_post.php
@@ -85,7 +85,7 @@
                     ';
                     // Display button to delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '  <button onclick="editPost()" class="btn btn-outline-info" style="text-align: left; display: inline;" id="edit-post-btn">Edit Post</button>
+                        echo '  <button onclick="editPost()" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
                                     <button type="submit" class="btn btn-danger" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>

--- a/view_post.php
+++ b/view_post.php
@@ -43,6 +43,7 @@
                             </div>
                         </div>
                     </div>
+                    <br><br><br>
                     <div class="container justify-content-center">
                         <div class="row justify-content-center">
                             <div class="col-12">

--- a/view_post.php
+++ b/view_post.php
@@ -16,7 +16,7 @@
 <body>
 
     <?php include 'navbar.php'; ?>
-    
+
     <!-- PHP script for displaying a post on the home page -->
     <?php 
     session_start();
@@ -170,7 +170,7 @@
     <script>
         function editComment(commentID) {
             commentID = commentID.toString();
-            document.getElementById('edit-form-' + commentID).style.display = "block";
+            // document.getElementById('edit-form-' + commentID).style.display = "block";
             document.getElementById('comment-content-' + commentID).style.display = "none";
         }
         function cancelEdit(commentID) {

--- a/view_post.php
+++ b/view_post.php
@@ -118,10 +118,6 @@
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
                                                         <div id="comment-content-'.$comment['commentID'].'">
                                                             <p class="card-text">'.$comment['content'].'</p>
-                        ';
-                        if($_SESSION['username'] == $comment['username']) {
-                            echo '
-                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: right;">Edit</button>
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
                                                                 <div class="card">
                                                                     <div class="card-body">
@@ -134,6 +130,10 @@
                                                                     </div>
                                                                 </div>
                                                             </div>
+                        ';
+                        if($_SESSION['username'] == $comment['username']) {
+                            echo '
+                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: right;">Edit</button>
                                                             <form method="post"  action="delete_comment.php" style="text-align: right;">
                                                                 <input type="hidden" name="commentID" value='.$comment['commentID'].'>
                                                                 <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete</button>

--- a/view_post.php
+++ b/view_post.php
@@ -169,9 +169,12 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
+            commentID = commentID.toString();
             document.getElementById('edit-form-' + commentID).style.display = "block";
         }
         function cancelEdit(commentID) {
+            commentID = commentID.toString();
+            document.getElementById('comment-content-' + commentID).style.display = "none";
             document.getElementById('edit-form-' + commentID).style = "none";
         }
     </script>

--- a/view_post.php
+++ b/view_post.php
@@ -116,7 +116,7 @@
                                                 <div class="card" id="comment-'.$comment['commentID'].'">
                                                     <div class="card-body">
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
-                                                        <div id="comment-content-'.$comment['commentID'].'">
+                                                        <div id="comment-content-'.$comment['commentID'].'" style="display:block;">
                                                             <p class="card-text">'.$comment['content'].'</p>
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:block;">
                                                                 <div class="card" style="margin-bottom: 15px;">

--- a/view_post.php
+++ b/view_post.php
@@ -57,18 +57,6 @@
                                         <img src="data:image/jpeg;base64,'.$imageData.'" class="card-img-top img-fluid mx-auto d-block"
                                             style="max-width: 400px; margin-bottom: .25em;" alt="Discussion Image">
                                         <p class="card-text">'.($row['content']).'</p>
-
-                                        <div id="post-edit-form" style="display:block;" class="card-body">
-                                            <form method="post" action="update_post.php" enctype="multipart/form-data">
-                                                <input type="hidden" name="discussionID" value='.($row['discussionID']).'>
-                                                <input type="text" name="title" value='.($row['title']).' required>
-                                                <textarea name="content" rows="5" required>'.($row['content']).'</textarea>
-                                                <input type="file" name="picture">
-                                                <input type="text" name="category" value='.($row['category']).' required>
-                                                <button type="submit">Update Post</button>
-                                            </form>
-                                        </div>
-
                                         <hr>
                                         <div class="d-flex justify-content-end mt-3">
                                             <button type="button" class="btn btn-outline-success me-2">+ ('.($row['upvotes']).')</button>
@@ -82,7 +70,7 @@
                     echo '
                                                 <div class="card mb-3">
                                                     <div class="card-body">
-                                                        <h5 class="card-title">Create a Comment</h5>
+                                                        <h5 class="card-title">Leave a comment!</h5>
                                                         <form method="post" action="create_comment.php">
                                                             <input type="hidden" name="discussionID" value='.$discussionId.'>
                                                             <div class="mb-3">
@@ -97,7 +85,7 @@
                     ';
                     // Display button to delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '  <button onclick="editPost()" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
+                        echo '  <button onclick="openEditModal('.($row['discussionID']).', '.($row['title'].)', '.($row['content']).', '.($row['category']).')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
                                     <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Post</button>
@@ -136,7 +124,7 @@
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
                                                                 <div class="card" style="margin-bottom: 15px;">
                                                                     <div class="card-body">
-                                                                    <h5 class="card-title">Edit Comment</h5>
+                                                                    <h5 class="card-title">Edit your comment:</h5>
                                                                         <form method="post" action="edit_comment.php">
                                                                             <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
                                                                             <textarea class="form-control" name="updatedContent" rows="3" style="margin-bottom: 15px;">'.($comment['content']).'</textarea>
@@ -205,7 +193,17 @@
             document.getElementById('post-display').style.display = 'block';
             document.getElementById('edit-comment-btn').style.display = "block";
             document.getElementById('delete-comment-btn').style.display = "block";
-    }
+        }
+        function openEditModal(discussionID, title, content, category) {
+            document.getElementById('editDiscussionID').value = discussionID;
+            document.getElementById('editPostTitle').value = title;
+            document.getElementById('editPostContent').value = content;
+            document.getElementById('editPostCategory').value = category;
+            var editModal = new bootstrap.Modal(document.getElementById('editPostModal'), {
+            keyboard: false
+            });
+            editModal.show();
+        }
     </script>
     <!-- BOOTSTRAP -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
@@ -224,6 +222,49 @@
             }
         });
     </script>
+
+        <!-- Edit Post Modal -->
+        <div class="modal fade" id="editPostModal" tabindex="-1" aria-labelledby="modal-title" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="editPostModalTitle">Edit your post:</h5>
+                </div>
+                <div class="modal-body">
+                    <form method="post" action="edit_post.php" enctype="multipart/form-data">
+                    <input type="hidden" name="discussionID" id="editDiscussionID">
+                        <div class="form-group row">
+                            <label for="editPostCategory" class="col-sm-2 col-form-label">Category</label>
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" id="editPostCategory" name="editPostCategory" placeholder="Enter post category">
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="editPostTitle" class="col-sm-2 col-form-label">Title</label>
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" id="editPostTitle" name="editPostTitle" placeholder="Enter post title...">
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="editPostImage" class="col-sm-2 col-form-label">Image</label>
+                            <div class="col-sm-10">
+                                <input type="file" id="editPostImage" name="editPostImage">
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="editPostContent">Description</label>
+                            <textarea class="form-control" id="editPostContent" name="editPostContent" rows="5" placeholder="Enter post description..."></textarea>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                            <button type="submit" class="btn btn-primary">Update Post</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
 </body>
 
 </html>

--- a/view_post.php
+++ b/view_post.php
@@ -86,7 +86,7 @@
                     // Display button to edit or delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
                         echo '   <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
-                                    <button onclick="openEditModal(' . htmlspecialchars($row['discussionID']) . ', ' . htmlspecialchars($row['title'], ENT_QUOTES) . ', ' . htmlspecialchars($row['content'], ENT_QUOTES) . ', ' . htmlspecialchars($row['category'], ENT_QUOTES) . ')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
+                                    <button onclick="openEditModal(\'' . htmlspecialchars($row['discussionID']) . '\', \'' . htmlspecialchars(addslashes($row['title']), ENT_QUOTES) . '\', \'' . htmlspecialchars(addslashes($row['content']), ENT_QUOTES) . '\', \'' . htmlspecialchars(addslashes($row['category']), ENT_QUOTES) . '\')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 </a>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">

--- a/view_post.php
+++ b/view_post.php
@@ -83,9 +83,11 @@
                                                     </div>
                                                 </div>
                     ';
-                    // Display button to delete post if user is author of post
+                    // Display button to edit or delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '  <button onclick="openEditModal('.($row['discussionID']).', '.($row['title']).', '.($row['content']).', '.($row['category']).')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
+                        echo '   <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
+                                    <button onclick="openEditModal('.$row['discussionID'].', \''.addslashes($row['title']).'\', \''.addslashes($row['content']).'\', \''.addslashes($row['category']).'\')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
+                                </a>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
                                     <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Post</button>
@@ -136,11 +138,7 @@
                                                             </div>
                         ';
                         if($_SESSION['username'] == $comment['username']) {
-                            echo '
-                                        <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
-                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>
-                                        </a>                            
-                                        <form method="post"  action="delete_comment.php" style="text-align: right;">
+                            echo '          <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>                                        <form method="post"  action="delete_comment.php" style="text-align: right;">
                                             <input type="hidden" name="commentID" value='.$comment['commentID'].'>
                                             <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
                                         </form>

--- a/view_post.php
+++ b/view_post.php
@@ -85,10 +85,10 @@
                     ';
                     // Display button to delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '  <button onclick="editPost()" class="btn btn-outline-info">Edit Post</button>
+                        echo '  <button onclick="editPost()" class="btn btn-outline-info" style="text-align: left; display: inline;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
-                                    <button type="submit" class="btn btn-danger" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
+                                    <button type="submit" class="btn btn-danger" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
                                 </form>';
                     }
                 }
@@ -139,7 +139,7 @@
                                                             <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>
                                                             <form method="post"  action="delete_comment.php" style="text-align: right;">
                                                                 <input type="hidden" name="commentID" value='.$comment['commentID'].'>
-                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: inline;" id="delete-comment-btn"onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
+                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
                                                             </form>
                             ';
                         }

--- a/view_post.php
+++ b/view_post.php
@@ -85,7 +85,7 @@
                     ';
                     // Display button to delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '  <button onclick="openEditModal('.($row['discussionID']).', '.($row['title'].)', '.($row['content']).', '.($row['category']).')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
+                        echo '  <button onclick="openEditModal('.($row['discussionID']).', '.($row['title'].).', '.($row['content']).', '.($row['category']).')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
                                     <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Post</button>

--- a/view_post.php
+++ b/view_post.php
@@ -123,12 +123,16 @@
                             echo '
                                                             <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: right;">Edit</button>
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
-                                                                <form method="post" action="edit_comment.php">
-                                                                    <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
-                                                                    <textarea class="form-control" name="updatedContent" rows="3">'.($comment['content']).'</textarea>
-                                                                    <button type="submit" class="btn btn-success btn-sm">Save</button>
-                                                                    <button type="button" onclick="cancelEdit('.$comment['commentID'].')" class="btn btn-secondary btn-sm">Cancel</button>
-                                                                </form>
+                                                                <div class="card">
+                                                                    <div class="card-body">
+                                                                        <form method="post" action="edit_comment.php">
+                                                                            <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
+                                                                            <textarea class="form-control" name="updatedContent" rows="3">'.($comment['content']).'</textarea>
+                                                                            <button type="submit" class="btn btn-success btn-sm">Save</button>
+                                                                            <button type="button" onclick="cancelEdit('.$comment['commentID'].')" class="btn btn-secondary btn-sm">Cancel</button>
+                                                                        </form>
+                                                                    </div>
+                                                                </div>
                                                             </div>
                                                             <form method="post"  action="delete_comment.php" style="text-align: right;">
                                                                 <input type="hidden" name="commentID" value='.$comment['commentID'].'>

--- a/view_post.php
+++ b/view_post.php
@@ -169,12 +169,11 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
-            console.log('<?php echo $comment["content"]; ?>');
-            document.getElementById('comment-' + commentID).style.display = 'none';
+            document.getElementById('comment-content-' + commentID).style.display = 'none';
             document.getElementById('edit-form-' + commentID).style.display = 'block';
         }
         function cancelEdit(commentID) {
-            document.getElementById('comment-' + commentID).style.display = 'block';
+            document.getElementById('comment-content-' + commentID).style.display = 'block';
             document.getElementById('edit-form-' + commentID).style.display = 'none';
         }
     </script>

--- a/view_post.php
+++ b/view_post.php
@@ -170,7 +170,7 @@
     <script>
         function editComment(commentID) {
             commentID = commentID.toString();
-            // document.getElementById('edit-form-' + commentID).style.display = "block";
+            document.getElementById('edit-form-' + commentID).style.display = "block";
             // document.getElementById('comment-content-' + commentID).style.display = "none";
         }
         function cancelEdit(commentID) {

--- a/view_post.php
+++ b/view_post.php
@@ -57,6 +57,18 @@
                                         <img src="data:image/jpeg;base64,'.$imageData.'" class="card-img-top img-fluid mx-auto d-block"
                                             style="max-width: 400px; margin-bottom: .25em;" alt="Discussion Image">
                                         <p class="card-text">'.($row['content']).'</p>
+
+                                        <div id="post-edit-form" style="display:block;" class="card-body">
+                                            <form method="post" action="update_post.php" enctype="multipart/form-data">
+                                                <input type="hidden" name="discussionID" value='.($row['discussionID']).'>
+                                                <input type="text" name="title" value='.($row['title']).' required>
+                                                <textarea name="content" rows="5" required>'.($row['content']).'</textarea>
+                                                <input type="file" name="picture">
+                                                <input type="text" name="category" value='.($row['category']).' required>
+                                                <button type="submit">Update Post</button>
+                                            </form>
+                                        </div>
+
                                         <hr>
                                         <div class="d-flex justify-content-end mt-3">
                                             <button type="button" class="btn btn-outline-success me-2">+ ('.($row['upvotes']).')</button>
@@ -88,7 +100,7 @@
                         echo '  <button onclick="editPost()" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
-                                    <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
+                                    <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Post</button>
                                 </form>';
                     }
                 }
@@ -124,11 +136,12 @@
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
                                                                 <div class="card" style="margin-bottom: 15px;">
                                                                     <div class="card-body">
+                                                                    <h5 class="card-title">Edit Comment</h5>
                                                                         <form method="post" action="edit_comment.php">
                                                                             <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
                                                                             <textarea class="form-control" name="updatedContent" rows="3" style="margin-bottom: 15px;">'.($comment['content']).'</textarea>
-                                                                            <button type="submit" class="btn btn-success btn-sm">Save</button>
-                                                                            <button type="button" onclick="cancelEdit('.$comment['commentID'].')" class="btn btn-secondary btn-sm">Cancel</button>
+                                                                            <button type="submit" class="btn btn-success btn-sm">Update</button>
+                                                                            <button type="button" onclick="cancelEditComment('.$comment['commentID'].')" class="btn btn-secondary btn-sm">Cancel</button>
                                                                         </form>
                                                                     </div>
                                                                 </div>
@@ -169,18 +182,30 @@
         die($e->getMessage());
     }
     ?>
-    <!-- JavaScript functions for editing comments -->
+    <!-- JavaScript functions for editing posts and comments -->
     <script>
         function editComment(commentID) {
             document.getElementById('edit-form-' + commentID).style.display = "block";
             document.getElementById('edit-comment-btn').style.display = "none";
             document.getElementById('delete-comment-btn').style.display = "none";
         }
-        function cancelEdit(commentID) {
+        function cancelEditComment(commentID) {
             document.getElementById('edit-form-' + commentID).style.display = "none";
             document.getElementById('edit-comment-btn').style.display = "inline";
             document.getElementById('delete-comment-btn').style.display = "inline";
         }
+        function editPost() {
+            document.getElementById('post-edit-form').style.display = 'block';
+            document.getElementById('post-display').style.display = 'none';
+            document.getElementById('edit-comment-btn').style.display = "none";
+            document.getElementById('delete-comment-btn').style.display = "none";
+        }
+        function cancelEditPost() {
+            document.getElementById('post-edit-form').style.display = 'none';
+            document.getElementById('post-display').style.display = 'block';
+            document.getElementById('edit-comment-btn').style.display = "block";
+            document.getElementById('delete-comment-btn').style.display = "block";
+    }
     </script>
     <!-- BOOTSTRAP -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"

--- a/view_post.php
+++ b/view_post.php
@@ -90,7 +90,7 @@
                                 </a>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
-                                    <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Post</button>
+                                    <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-post-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Post</button>
                                 </form>';
                     }
                 }
@@ -138,7 +138,8 @@
                                                             </div>
                         ';
                         if($_SESSION['username'] == $comment['username']) {
-                            echo '          <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>                                        <form method="post"  action="delete_comment.php" style="text-align: right;">
+                            echo '      <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>                                        
+                                        <form method="post"  action="delete_comment.php" style="text-align: right;">
                                             <input type="hidden" name="commentID" value='.$comment['commentID'].'>
                                             <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
                                         </form>
@@ -185,14 +186,14 @@
         function editPost() {
             document.getElementById('post-edit-form').style.display = 'block';
             document.getElementById('post-display').style.display = 'none';
-            document.getElementById('edit-comment-btn').style.display = "none";
-            document.getElementById('delete-comment-btn').style.display = "none";
+            document.getElementById('edit-post-btn').style.display = "none";
+            document.getElementById('delete-post-btn').style.display = "none";
         }
         function cancelEditPost() {
             document.getElementById('post-edit-form').style.display = 'none';
             document.getElementById('post-display').style.display = 'block';
-            document.getElementById('edit-comment-btn').style.display = "block";
-            document.getElementById('delete-comment-btn').style.display = "block";
+            document.getElementById('edit-post-btn').style.display = "block";
+            document.getElementById('delete-post-btn').style.display = "block";
         }
         function openEditModal(discussionID, title, content, category) {
             document.getElementById('editDiscussionID').value = discussionID;

--- a/view_post.php
+++ b/view_post.php
@@ -118,7 +118,7 @@
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
                                                         <div id="comment-content-'.$comment['commentID'].'" style="display:block;">
                                                             <p class="card-text">'.$comment['content'].'</p>
-                                                            <div id="edit-form-'.$comment['commentID'].'">
+                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
                                                                 <div class="card" style="margin-bottom: 15px;">
                                                                     <div class="card-body">
                                                                         <form method="post" action="edit_comment.php">

--- a/view_post.php
+++ b/view_post.php
@@ -137,11 +137,13 @@
                         ';
                         if($_SESSION['username'] == $comment['username']) {
                             echo '
-                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>
-                                                            <form method="post"  action="delete_comment.php" style="text-align: right;">
-                                                                <input type="hidden" name="commentID" value='.$comment['commentID'].'>
-                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
-                                                            </form>
+                                        <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
+                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>
+                                        </a>                            
+                                        <form method="post"  action="delete_comment.php" style="text-align: right;">
+                                            <input type="hidden" name="commentID" value='.$comment['commentID'].'>
+                                            <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
+                                        </form>
                             ';
                         }
                         echo '
@@ -199,10 +201,6 @@
             document.getElementById('editPostTitle').value = title;
             document.getElementById('editPostContent').value = content;
             document.getElementById('editPostCategory').value = category;
-            var editModal = new bootstrap.Modal(document.getElementById('editPostModal'), {
-            keyboard: false
-            });
-            editModal.show();
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -88,7 +88,7 @@
                         echo '  <button onclick="editPost()" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
-                                    <button type="submit" class="btn btn-danger" style="text-align: right; display: inline;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
+                                    <button type="submit" class="btn btn-danger" style="text-align: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Discussion</button>
                                 </form>';
                     }
                 }

--- a/view_post.php
+++ b/view_post.php
@@ -118,7 +118,7 @@
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
                                                         <div id="comment-content-'.$comment['commentID'].'" style="display:block;">
                                                             <p class="card-text">'.$comment['content'].'</p>
-                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:block;">
+                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
                                                                 <div class="card" style="margin-bottom: 15px;">
                                                                     <div class="card-body">
                                                                         <form method="post" action="edit_comment.php">
@@ -169,10 +169,12 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
+            commentID = commentID.toString();
             document.getElementById('comment-content-' + commentID).style.display = 'none';
             document.getElementById('edit-form-' + commentID).style.display = 'block';
         }
         function cancelEdit(commentID) {
+            commentID = commentID.toString();
             document.getElementById('comment-content-' + commentID).style.display = 'block';
             document.getElementById('edit-form-' + commentID).style.display = 'none';
         }

--- a/view_post.php
+++ b/view_post.php
@@ -123,7 +123,7 @@
                                                                     <div class="card-body">
                                                                         <form method="post" action="edit_comment.php">
                                                                             <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
-                                                                            <textarea class="form-control" name="updatedContent" rows="3">'.($comment['content']).'</textarea>
+                                                                            <textarea class="form-control" name="updatedContent" rows="3" style="margin-bottom: 5px;">'.($comment['content']).'</textarea>
                                                                             <button type="submit" class="btn btn-success btn-sm">Save</button>
                                                                             <button type="button" onclick="cancelEdit('.$comment['commentID'].')" class="btn btn-secondary btn-sm">Cancel</button>
                                                                         </form>

--- a/view_post.php
+++ b/view_post.php
@@ -26,7 +26,10 @@
             $discussionId = $_GET['discussionID'];
             $_SESSION['discussionID'] = $discussionId;
             $query = "SELECT * FROM Discussions WHERE discussionID = " . $discussionId;
-            $result = $conn->query($query);
+            $stmt = $conn->prepare($query);
+            $stmt->bind_param("i", $discussionId);
+            $stmt->execute();
+            $result = $stmt->get_result();
             if ($result->num_rows > 0) {
                 $row = $result->fetch_assoc();
                 $imageData = base64_encode($row['discussion_picture']);
@@ -49,7 +52,7 @@
                             <div class="col-12">
                                 <div class="card">
                                     <div class="card-body">
-                                        <p class="card-text"><strong>Posted by: ✏️ </strong>'.($row['username']).' | <strong>Published on:</strong>
+                                        <p class="card-text"><strong>Posted by: ✏️ </strong>'.($row['username']).' | <strong>Published on:</strong>  | <i><strong>'.($row['category']).'</strong></i>
                                         '.($row['time_posted']).'</p>
                                         <h4 class="card-title">'.($row['title']).'</h4>
                                         <img src="data:image/jpeg;base64,'.$imageData.'" class="card-img-top img-fluid mx-auto d-block"

--- a/view_post.php
+++ b/view_post.php
@@ -85,8 +85,8 @@
                     ';
                     // Display button to edit or delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '   <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
-                                    <button onclick="openEditModal('.$row['discussionID'].', \''.addslashes($row['title']).'\', \''.addslashes($row['content']).'\', \''.addslashes($row['category']).'\')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
+                        echo '  <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
+                                    <button class="btn btn-outline-info edit-post-btn" data-bs-toggle="modal" data-bs-target="#editPostModal" data-discussionid="' . htmlspecialchars($row['discussionID']) . '" data-title="' . htmlspecialchars($row['title'], ENT_QUOTES) . '" data-content="' . htmlspecialchars($row['content'], ENT_QUOTES) . '" data-category="' . htmlspecialchars($row['category'], ENT_QUOTES) . '" style="text-align: left; display: block;">Edit Post</button>
                                 </a>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">

--- a/view_post.php
+++ b/view_post.php
@@ -118,7 +118,7 @@
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
                                                         <div id="comment-content-'.$comment['commentID'].'" style="display:block;">
                                                             <p class="card-text">'.$comment['content'].'</p>
-                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
+                                                            <div id="edit-form-'.$comment['commentID'].'">
                                                                 <div class="card" style="margin-bottom: 15px;">
                                                                     <div class="card-body">
                                                                         <form method="post" action="edit_comment.php">
@@ -171,7 +171,7 @@
         function editComment(commentID) {
             commentID = commentID.toString();
             document.getElementById('comment-content-' + commentID).style.display = "none";
-            document.getElementById('edit-form-' + commentID).style.display = "block";
+            document.getElementById('edit-form-' + commentID).style.display = "none";
         }
         function cancelEdit(commentID) {
             commentID = commentID.toString();

--- a/view_post.php
+++ b/view_post.php
@@ -16,8 +16,7 @@
 <body>
 
     <?php include 'navbar.php'; ?>
-    <script>hideForm()</script>
-
+    
     <!-- PHP script for displaying a post on the home page -->
     <?php 
     session_start();
@@ -169,9 +168,6 @@
     ?>
     <!-- JavaScript functions for editing comments -->
     <script>
-        function hideForm() {
-            document.getElementById('edit-form-' + commentID).style.display = "none";
-        }
         function editComment(commentID) {
             commentID = commentID.toString();
             document.getElementById('edit-form-' + commentID).style.display = "block";

--- a/view_post.php
+++ b/view_post.php
@@ -52,8 +52,7 @@
                             <div class="col-12">
                                 <div class="card">
                                     <div class="card-body">
-                                        <p class="card-text"><strong>Posted by: ✏️ </strong>'.($row['username']).' | <strong>Published on:</strong>  | <i><strong>'.($row['category']).'</strong></i>
-                                        '.($row['time_posted']).'</p>
+                                        <p class="card-text"><strong>Posted by: ✏️ </strong>'.($row['username']).' | <strong>Published on:</strong> '.($row['time_posted']).' | <i><strong>'.($row['category']).'</strong></i></p>
                                         <h4 class="card-title">'.($row['title']).'</h4>
                                         <img src="data:image/jpeg;base64,'.$imageData.'" class="card-img-top img-fluid mx-auto d-block"
                                             style="max-width: 400px; margin-bottom: .25em;" alt="Discussion Image">

--- a/view_post.php
+++ b/view_post.php
@@ -43,7 +43,7 @@
                             </div>
                         </div>
                     </div>
-                    <br><br><br>
+                    <br><br>
                     <div class="container justify-content-center">
                         <div class="row justify-content-center">
                             <div class="col-12">
@@ -134,6 +134,7 @@
                             </div>
                         </div>
                     </div>
+                    <br><br>
                 ';
             } else {
                 echo "Could not find any posts with this discussionID.";

--- a/view_post.php
+++ b/view_post.php
@@ -85,8 +85,8 @@
                     ';
                     // Display button to edit or delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '  <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
-                                    <button class="btn btn-outline-info edit-post-btn" data-bs-toggle="modal" data-bs-target="#editPostModal" data-discussionid="' . htmlspecialchars($row['discussionID']) . '" data-title="' . htmlspecialchars($row['title'], ENT_QUOTES) . '" data-content="' . htmlspecialchars($row['content'], ENT_QUOTES) . '" data-category="' . htmlspecialchars($row['category'], ENT_QUOTES) . '" style="text-align: left; display: block;">Edit Post</button>
+                        echo '   <a class="nav-link active" type="button" aria-disabled="true" data-bs-toggle="modal" data-bs-target="#editPostModal">
+                                    <button onclick="openEditModal(' . htmlspecialchars($row['discussionID']) . ', ' . htmlspecialchars($row['title'], ENT_QUOTES) . ', ' . htmlspecialchars($row['content'], ENT_QUOTES) . ', ' . htmlspecialchars($row['category'], ENT_QUOTES) . ')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 </a>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">

--- a/view_post.php
+++ b/view_post.php
@@ -136,10 +136,10 @@
                         ';
                         if($_SESSION['username'] == $comment['username']) {
                             echo '
-                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: block;" id="edit-comment-btn">Edit Comment</button>
+                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: inline;" id="edit-comment-btn">Edit Comment</button>
                                                             <form method="post"  action="delete_comment.php" style="text-align: right;">
                                                                 <input type="hidden" name="commentID" value='.$comment['commentID'].'>
-                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: block;" id="delete-comment-btn"onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
+                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: inline;" id="delete-comment-btn"onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
                                                             </form>
                             ';
                         }

--- a/view_post.php
+++ b/view_post.php
@@ -16,6 +16,7 @@
 <body>
 
     <?php include 'navbar.php'; ?>
+    <script>hideForm()</script>
 
     <!-- PHP script for displaying a post on the home page -->
     <?php 
@@ -168,10 +169,13 @@
     ?>
     <!-- JavaScript functions for editing comments -->
     <script>
+        function hideForm() {
+            document.getElementById('edit-form-' + commentID).style.display = "none";
+        }
         function editComment(commentID) {
             commentID = commentID.toString();
+            document.getElementById('edit-form-' + commentID).style.display = "block";
             document.getElementById('comment-content-' + commentID).style.display = "none";
-            document.getElementById('edit-form-' + commentID).style.display = "none";
         }
         function cancelEdit(commentID) {
             commentID = commentID.toString();

--- a/view_post.php
+++ b/view_post.php
@@ -95,8 +95,11 @@
                                 <br>
                 ';
                 // Dynamically generate comments here
-                $query2 = "SELECT * FROM Comments WHERE discussionID = " . $discussionId;
-                $result2 = $conn->query($query2);
+                $query2 = "SELECT * FROM Comments WHERE discussionID = ?";
+                $stmt2 = $conn->prepare($query2);
+                $stmt2->bind_param("i", $discussionId);
+                $stmt2->execute();
+                $result2 = $stmt2->get_result();
                 $num_comments = $result2->num_rows;
                 if ($num_comments > 0) {
                     if($num_comments == 1) {
@@ -110,24 +113,31 @@
                     }
                     while ($comment = $result2->fetch_assoc()) {
                         echo '
-                                                <div class="card" id="comment">
+                                                <div class="card" id="comment-'.$comment['commentID'].'">
                                                     <div class="card-body">
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
-                                                        <p class="card-text">' . $comment['content'] . '</p>
+                                                        <div id="comment-content-'.$comment['commentID'].'">
+                                                            <p class="card-text">'.$comment['content'].'</p>
                         ';
                         if($_SESSION['username'] == $comment['username']) {
                             echo '
-                                                        <form method="post" action="edit_comment.php" style="text-align: right;">
-                                                            <input type="hidden" name="commentID" value='.$comment['commentID'].'>
-                                                            <button type="submit" class="btn btn-danger btn-sm";">Edit</button>
-                                                        </form>
-                                                        <form method="post"  action="delete_comment.php" style="text-align: right;">
-                                                            <input type="hidden" name="commentID" value='.$comment['commentID'].'>
-                                                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete</button>
-                                                        </form>
+                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: right;">Edit</button>
+                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
+                                                                <form method="post" action="edit_comment.php">
+                                                                    <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
+                                                                    <textarea class="form-control" name="updatedContent" rows="3">'.($comment['content']).'</textarea>
+                                                                    <button type="submit" class="btn btn-success btn-sm">Save</button>
+                                                                    <button type="button" onclick="cancelEdit('.$comment['commentID'].')" class="btn btn-secondary btn-sm">Cancel</button>
+                                                                </form>
+                                                            </div>
+                                                            <form method="post"  action="delete_comment.php" style="text-align: right;">
+                                                                <input type="hidden" name="commentID" value='.$comment['commentID'].'>
+                                                                <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete</button>
+                                                            </form>
                             ';
                         }
                         echo '
+                                                        </div>
                                                     </div>
                                                 </div>
                             ';
@@ -152,6 +162,17 @@
         die($e->getMessage());
     }
     ?>
+    <!-- JavaScript functions for editing comments -->
+    <script>
+        function editComment(commentID) {
+            document.getElementById('comment-content-' + commentID).style.display = 'none';
+            document.getElementById('edit-form-' + commentID).style.display = 'block';
+        }
+        function cancelEdit(commentID) {
+            document.getElementById('comment-content-' + commentID).style.display = 'block';
+            document.getElementById('edit-form-' + commentID).style.display = 'none';
+        }
+        </script>
     <!-- BOOTSTRAP -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"

--- a/view_post.php
+++ b/view_post.php
@@ -120,10 +120,10 @@
                                                             <p class="card-text">'.$comment['content'].'</p>
                                                             <div id="edit-form-'.$comment['commentID'].'" style="display:block;">
                                                                 <div class="card">
-                                                                    <div class="card-body">
+                                                                    <div class="card-body" style="margin-bottom: 15px;">
                                                                         <form method="post" action="edit_comment.php">
                                                                             <input type="hidden" name="commentID" value="'.$comment['commentID'].'">
-                                                                            <textarea class="form-control" name="updatedContent" rows="3" style="margin-bottom: 5px;">'.($comment['content']).'</textarea>
+                                                                            <textarea class="form-control" name="updatedContent" rows="3" style="margin-bottom: 15px;">'.($comment['content']).'</textarea>
                                                                             <button type="submit" class="btn btn-success btn-sm">Save</button>
                                                                             <button type="button" onclick="cancelEdit('.$comment['commentID'].')" class="btn btn-secondary btn-sm">Cancel</button>
                                                                         </form>

--- a/view_post.php
+++ b/view_post.php
@@ -165,6 +165,7 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
+            console.log('<?php echo $comment["content"]; ?>');
             document.getElementById('comment-content-' + commentID).style.display = 'none';
             document.getElementById('edit-form-' + commentID).style.display = 'block';
         }
@@ -172,7 +173,7 @@
             document.getElementById('comment-content-' + commentID).style.display = 'block';
             document.getElementById('edit-form-' + commentID).style.display = 'none';
         }
-        </script>
+    </script>
     <!-- BOOTSTRAP -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"

--- a/view_post.php
+++ b/view_post.php
@@ -169,14 +169,14 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
-            console.log(typeof commentID);
-            document.getElementById('comment-content-' + commentID).style.display = 'none';
-            document.getElementById('edit-form-' + commentID).style.display = 'block';
+            commentID = commentID.toString();
+            document.getElementById('comment-content-' + commentID).style.display = "none";
+            document.getElementById('edit-form-' + commentID).style.display = "block";
         }
         function cancelEdit(commentID) {
             commentID = commentID.toString();
-            document.getElementById('comment-content-' + commentID).style.display = 'block';
-            document.getElementById('edit-form-' + commentID).style.display = 'none';
+            document.getElementById('comment-content-' + commentID).style.display = "block";
+            document.getElementById('edit-form-' + commentID).style = "none";
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -169,12 +169,9 @@
     <!-- JavaScript functions for editing comments -->
     <script>
         function editComment(commentID) {
-            commentID = commentID.toString();
             document.getElementById('edit-form-' + commentID).style.display = "block";
         }
         function cancelEdit(commentID) {
-            commentID = commentID.toString();
-            document.getElementById('comment-content-' + commentID).style.display = "none";
             document.getElementById('edit-form-' + commentID).style = "none";
         }
     </script>

--- a/view_post.php
+++ b/view_post.php
@@ -136,10 +136,10 @@
                         ';
                         if($_SESSION['username'] == $comment['username']) {
                             echo '
-                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: right; display: inline;" id="edit-comment-btn">Edit Comment</button>
+                                                            <button onclick="editComment('.$comment['commentID'].')" class="btn btn-outline-info btn-sm style="text-align: left; display: block;" id="edit-comment-btn">Edit Comment</button>
                                                             <form method="post"  action="delete_comment.php" style="text-align: right;">
                                                                 <input type="hidden" name="commentID" value='.$comment['commentID'].'>
-                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: left; display: inline;" id="delete-comment-btn"onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
+                                                                <button type="submit" class="btn btn-danger btn-sm" style="text-align: right; display: block;" id="delete-comment-btn"onclick="return confirm(\'Are you sure you want to delete this comment?\');">Delete Comment</button>
                                                             </form>
                             ';
                         }
@@ -178,8 +178,8 @@
         }
         function cancelEdit(commentID) {
             document.getElementById('edit-form-' + commentID).style.display = "none";
-            document.getElementById('edit-comment-btn').style.display = "block";
-            document.getElementById('delete-comment-btn').style.display = "none";
+            document.getElementById('edit-comment-btn').style.display = "inline";
+            document.getElementById('delete-comment-btn').style.display = "inline";
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -171,12 +171,12 @@
         function editComment(commentID) {
             commentID = commentID.toString();
             // document.getElementById('edit-form-' + commentID).style.display = "block";
-            document.getElementById('comment-content-' + commentID).style.display = "none";
+            // document.getElementById('comment-content-' + commentID).style.display = "none";
         }
         function cancelEdit(commentID) {
             commentID = commentID.toString();
-            document.getElementById('comment-content-' + commentID).style.display = "block";
-            document.getElementById('edit-form-' + commentID).style = "none";
+            // document.getElementById('comment-content-' + commentID).style.display = "block";
+            // document.getElementById('edit-form-' + commentID).style = "none";
         }
     </script>
     <!-- BOOTSTRAP -->

--- a/view_post.php
+++ b/view_post.php
@@ -118,7 +118,7 @@
                                                         <p class="card-text"><strong>Written By: ' . $comment['username'] . ' ✏️ | ' . $comment['timePosted'] . '</strong></p>
                                                         <div id="comment-content-'.$comment['commentID'].'">
                                                             <p class="card-text">'.$comment['content'].'</p>
-                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:none;">
+                                                            <div id="edit-form-'.$comment['commentID'].'" style="display:block;">
                                                                 <div class="card">
                                                                     <div class="card-body">
                                                                         <form method="post" action="edit_comment.php">

--- a/view_post.php
+++ b/view_post.php
@@ -222,45 +222,45 @@
 
         <!-- Edit Post Modal -->
         <div class="modal fade" id="editPostModal" tabindex="-1" aria-labelledby="modal-title" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="editPostModalTitle">Edit your post:</h5>
-                </div>
-                <div class="modal-body">
-                    <form method="post" action="edit_post.php" enctype="multipart/form-data">
-                    <input type="hidden" name="discussionID" id="editDiscussionID">
-                        <div class="form-group row">
-                            <label for="editPostCategory" class="col-sm-2 col-form-label">Category</label>
-                            <div class="col-sm-10">
-                                <input type="text" class="form-control" id="editPostCategory" name="editPostCategory" placeholder="Enter post category">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="editPostModalTitle">Edit your post:</h5>
+                    </div>
+                    <div class="modal-body">
+                        <form method="post" action="edit_post.php" enctype="multipart/form-data">
+                        <input type="hidden" name="discussionID" id="editDiscussionID">
+                            <div class="form-group row">
+                                <label for="editPostCategory" class="col-sm-2 col-form-label">Category</label>
+                                <div class="col-sm-10">
+                                    <input type="text" class="form-control" id="editPostCategory" name="editPostCategory" placeholder="Enter post category...">
+                                </div>
                             </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="editPostTitle" class="col-sm-2 col-form-label">Title</label>
-                            <div class="col-sm-10">
-                                <input type="text" class="form-control" id="editPostTitle" name="editPostTitle" placeholder="Enter post title...">
+                            <div class="form-group row">
+                                <label for="editPostTitle" class="col-sm-2 col-form-label">Title</label>
+                                <div class="col-sm-10">
+                                    <input type="text" class="form-control" id="editPostTitle" name="editPostTitle" placeholder="Enter post title...">
+                                </div>
                             </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="editPostImage" class="col-sm-2 col-form-label">Image</label>
-                            <div class="col-sm-10">
-                                <input type="file" id="editPostImage" name="editPostImage">
+                            <div class="form-group row">
+                                <label for="editPostImage" class="col-sm-2 col-form-label">Image</label>
+                                <div class="col-sm-10">
+                                    <input type="file" id="editPostImage" name="editPostImage">
+                                </div>
                             </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="editPostContent">Description</label>
-                            <textarea class="form-control" id="editPostContent" name="editPostContent" rows="5" placeholder="Enter post description..."></textarea>
-                        </div>
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                            <button type="submit" class="btn btn-primary">Update Post</button>
-                        </div>
-                    </form>
+                            <div class="form-group row">
+                                <label for="editPostContent">Description</label>
+                                <textarea class="form-control" id="editPostContent" name="editPostContent" rows="5" placeholder="Enter post description..."></textarea>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                <button type="submit" class="btn btn-primary">Update Post</button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
 </body>
 

--- a/view_post.php
+++ b/view_post.php
@@ -85,7 +85,7 @@
                     ';
                     // Display button to delete post if user is author of post
                     if ($_SESSION['username'] == $row['username']) {
-                        echo '  <button onclick="openEditModal('.($row['discussionID']).', '.($row['title'].).', '.($row['content']).', '.($row['category']).')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
+                        echo '  <button onclick="openEditModal('.($row['discussionID']).', '.($row['title']).', '.($row['content']).', '.($row['category']).')" class="btn btn-outline-info" style="text-align: left; display: block;" id="edit-post-btn">Edit Post</button>
                                 <form method="post" action="delete_discussion.php">
                                     <input type="hidden" name="discussionID" value="'.$discussionId.'">
                                     <button type="submit" class="btn btn-danger" style="float: right; display: block;" id="delete-comment-btn" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete Post</button>


### PR DESCRIPTION
## This PR:

- Users can now create, edit, and delete both discussions and comments only if they were the authors of the discussion/comment.

- Comments can be edited with a hidden form that appears when a user clicks the edit button (edit button only appears on a comments made by the logged in user).

- If a user clicks cancel while updating a comment, the characters typed before clicking cancel will still be there if the user clicks on the edit button again for that comment ONLY if they stay on the page and click no other buttons (since that will clear the cache).

- Posts can be edited with a modal pop up (similar to how a pop up appears when users want to create a post) with the ability to change post title, category, content, and image.

- Posts and comments are both deleted by pressing delete, upon clicking either delete button, the user will have to confirm with a javascript  confirm popup.

Closes #54 #51 