### PR TITLE
MD5 Security and Admin View Usage Reports

### DIFF
--- a/login.php
+++ b/login.php
@@ -6,12 +6,13 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $username = $_POST['username'];
     $password = $_POST['password'];
 
-    $username = mysqli_real_escape_string($conn, $username);
-    if(substr($password, -6) === ".Admin") {
-        $password = mysqli_real_escape_string($conn, $password);
-    } else {
-        $password = md5(mysqli_real_escape_string($conn, $password));
+    if (substr($username, -6) !== ".Admin") {
+        $password = md5($password);
     }
+
+    $username = mysqli_real_escape_string($conn, $username);
+    $password = mysqli_real_escape_string($conn, $password);
+
 
     $user_query = "SELECT * FROM User WHERE username = '$username' AND password = '$password'";
     $result = mysqli_query($conn, $user_query);

--- a/login.php
+++ b/login.php
@@ -7,6 +7,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $password = $_POST['password'];
 
     $username = mysqli_real_escape_string($conn, $username);
+    if(substr($password, -6) === ".Admin") {
+        $password = mysqli_real_escape_string($conn, $password);
+    }
     $password = md5(mysqli_real_escape_string($conn, $password));
 
 

--- a/login.php
+++ b/login.php
@@ -9,9 +9,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $username = mysqli_real_escape_string($conn, $username);
     if(substr($password, -6) === ".Admin") {
         $password = mysqli_real_escape_string($conn, $password);
+    } else {
+        $password = md5(mysqli_real_escape_string($conn, $password));
     }
-    $password = md5(mysqli_real_escape_string($conn, $password));
-
 
     $user_query = "SELECT * FROM User WHERE username = '$username' AND password = '$password'";
     $result = mysqli_query($conn, $user_query);

--- a/login.php
+++ b/login.php
@@ -7,7 +7,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $password = $_POST['password'];
 
     $username = mysqli_real_escape_string($conn, $username);
-    $password = mysqli_real_escape_string($conn, $password);
+    $password = md5(mysqli_real_escape_string($conn, $password));
 
 
     $user_query = "SELECT * FROM User WHERE username = '$username' AND password = '$password'";

--- a/register.php
+++ b/register.php
@@ -75,7 +75,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         
         if ($result->num_rows == 0) {
             $insert_stmt = $conn->prepare("INSERT INTO User (username, password, email, dob, profile_picture) VALUES (?, ?, ?, ?, ?)");
-            $insert_stmt->bind_param("sssss", $username, $password, $email, $dob, $profilePicture);
+            $insert_stmt->bind_param("sssss", $username, md5($password), $email, $dob, $profilePicture);
 
             if ($insert_stmt->execute()) {
 

--- a/update_info.php
+++ b/update_info.php
@@ -14,14 +14,14 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $username = $_POST['username'];
     $email = $_POST['email'];
     $dob = $_POST['DOB'];
-    $password = $_POST['password'];
-    $new_password = $_POST['new_password'];
+    $password = md5($_POST['password']);
+    $new_password = md5($_POST['new_password']);
 
     $update_query = "UPDATE User SET username = '$username', email = '$email', dob = '$dob'";
     
 
     if (!empty($new_password)) {
-        $update_query .= ", password = ".md5($new_password);
+        $update_query .= ", password = '$new_password'";
     }
 
     $update_query .= " WHERE userID = '$user_id'";

--- a/update_info.php
+++ b/update_info.php
@@ -21,7 +21,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
 
     if (!empty($new_password)) {
-        $update_query .= ", password = '$new_password'";
+        $update_query .= ", password = ".md5($new_password);
     }
 
     $update_query .= " WHERE userID = '$user_id'";


### PR DESCRIPTION
## In this PR:

- Changed password to implement MD5 hash for non-admins. Non-admins are able to register, login, logout, and change their passwords with a MD5 hash encryption.
- Admins are only able to register and change their passwords through the php my admin portal (which makes more sense since it is more secure).
- Admins are now able to view usage reports on the home page (graphs).

Closes #94 #88 